### PR TITLE
Add Msys2 auto-install support

### DIFF
--- a/installer/nightly.sh
+++ b/installer/nightly.sh
@@ -135,14 +135,14 @@ verifyOS(){
     case "$OSTYPE" in
         linux*)     currentOS="Linux" ;;
         linux-gnu*) currentOS="Linux" ;;
-        darwin*)    currentOS="macOS" ;; 
+        darwin*)    currentOS="macOS" ;;
         cygwin*)    currentOS="Windows" ;;
-        msys*)      currentOS="Windows" ;;
+        msys*)      currentOS="WindowsMsys2" ;;
         solaris*)   currentOS="Solaris" ;;
         freebsd*)   currentOS="FreeBSD" ;;
         bsd*)       currentOS="BSD" ;;
-        *)         
-            if [ `uname` = "Linux" ]; then 
+        *)
+            if [ `uname` = "Linux" ]; then
                 currentOS="Linux"
             elif [ `uname` = "FreeBSD" ]; then
                 currentOS="FreeBSD"
@@ -156,16 +156,16 @@ verifyOS(){
 
 verifyShell(){
     case "$SHELL" in
-        "/bin/zsh")     
+        "/bin/zsh")
             currentShell="zsh" ;
             shellRcFile="~/.zshrc" ;;
-        "/bin/bash")    
+        "/bin/bash")
             currentShell="bash" ;
             shellRcFile="~/.bashrc or ~/.profile" ;;
-        "/bin/sh")      
+        "/bin/sh")
             currentSheel="sh" ;
             shellRcFile="~/.profile" ;;
-        *)              
+        *)
             currentShell="unrecognized" ;
             shellRcFile="~/.profile" ;;
     esac
@@ -220,7 +220,7 @@ main() {
     if [ "$currentOS" = "Linux" ] || [ "$currentOS" = "macOS" ]; then
         section "Checking prerequisites..."
         install_prerequisites
-        
+
         section "Downloading..."
         download_arturo
 

--- a/installer/nightly.sh
+++ b/installer/nightly.sh
@@ -286,6 +286,23 @@ main() {
         section "Done!"
         eecho ""
         showFooter
+
+    elif [[ "$currentOS" = "WindowsMsys2" ]]; then
+        section "Creating environment..."
+        info "\nOS: $currentOS"
+        msys_create_arturo_path
+
+        section "Downloading..."
+        msys_download_arturo
+
+        section "Cleaning up..."
+        msys_cleanup
+
+        eecho ""
+
+        section "Done!"
+        eecho ""
+        showFooter
     else
         panic "Cannot continue. Unfortunately your OS is not supported by this auto-installer."
     fi

--- a/installer/nightly.sh
+++ b/installer/nightly.sh
@@ -205,6 +205,57 @@ install_arturo() {
     cp $ARTURO_TMP_DIR/arturo ~/.arturo/bin
 }
 
+msys_create_arturo_path() {
+
+    ARTURO_DIR="$HOME/.arturo"
+
+    create_directory "$ARTURO_DIR/bin"
+    create_directory "$ARTURO_DIR/lib"
+    # info "~/.arturo/bin and ~/.arturo/lib created!"
+}
+
+msys_download_arturo() {
+
+    BIN_PATH="$ARTURO_DIR/bin"
+    get_download_url $currentOS
+
+    # info "Arturo downloaded into ~/.arturo/bin Folder!"
+    curl -sSL $downloadUrl --output "$BIN_PATH/arturo.tar.gz"
+
+    # info "Unpacking Arturo..."
+    tar -zxf "$BIN_PATH/arturo.tar.gz" -C $BIN_PATH
+    # info "Unpacked!"
+
+}
+
+# To generate this file on Msys2, use:
+# curl -sSL \
+#  https://github.com/arturo-lang/arturo/releases/download/v0.9.80/arturo-0.9.80-Windows-full.zip \
+#  --output /home/development/arturo_setup/arturo.zip
+# explorer .
+# Unzip with WinRar with extract here, and run:
+# tar czf arturo.tar.gz arturo-full-windows-latest/*
+msys_fake_download_arturo() {
+    # simulates the tar.gz for WindowsMsys2
+    # The file is the same .zip for Windows
+    # But the format is .tar.gz for unpack with tar command
+    BIN_PATH="$ARTURO_DIR/bin"
+    cp /home/development/arturo_setup/arturo.tar.gz $BIN_PATH
+    # info "Arturo downloaded into ~/.arturo/bin Folder!"
+
+    # info "Unpacking Arturo..."
+    tar -zxf "$BIN_PATH/arturo.tar.gz" -C $BIN_PATH
+    mv $BIN_PATH/arturo-full-windows-latest/* $BIN_PATH/
+    # info "Unpacked!"
+
+}
+
+msys_cleanup() {
+    rm -f "$BIN_PATH/arturo.tar.gz"
+    rm --dir -f "$BIN_PATH/arturo-full-windows-latest"
+    # info "~/.arturo/bin/arturo.tar.gz and ~/.arturo/bin/arturo-full-windows-latest/ removed!"
+}
+
 ################################################
 # MAIN
 ################################################

--- a/installer/stable.sh
+++ b/installer/stable.sh
@@ -230,7 +230,8 @@ msys_download_arturo() {
 
 msys_cleanup() {
     rm -f "$BIN_PATH/arturo.tar.gz"
-    info "~/.arturo/bin/arturo.tar.gz removed!"
+    rm --dir -f "$BIN_PATH/arturo-full-windows-latest"
+    info "~/.arturo/bin/arturo.tar.gz and ~/.arturo/bin/arturo-full-windows-latest/ removed!"
 }
 
 ################################################

--- a/installer/stable.sh
+++ b/installer/stable.sh
@@ -228,6 +228,28 @@ msys_download_arturo() {
 
 }
 
+# To generate this file on Msys2, use:
+# curl -sSL \
+#  https://github.com/arturo-lang/arturo/releases/download/v0.9.80/arturo-0.9.80-Windows-full.zip \
+#  --output /home/development/arturo_setup/arturo.zip
+# explorer .
+# Unzip with WinRar with extract here, and run:
+# tar czf arturo.tar.gz arturo-full-windows-latest/*
+msys_fake_download_arturo() {
+    # simulates the tar.gz for WindowsMsys2
+    # The file is the same .zip for Windows
+    # But the format is .tar.gz for unpack with tar command
+    BIN_PATH="$ARTURO_DIR/bin"
+    cp /home/development/arturo_setup/arturo.tar.gz $BIN_PATH
+    info "Arturo downloaded into ~/.arturo/bin Folder!"
+
+    info "Unpacking Arturo..."
+    tar -zxf "$BIN_PATH/arturo.tar.gz" -C $BIN_PATH
+    mv $BIN_PATH/arturo-full-windows-latest/* $BIN_PATH/
+    info "Unpacked!"
+
+}
+
 msys_cleanup() {
     rm -f "$BIN_PATH/arturo.tar.gz"
     rm --dir -f "$BIN_PATH/arturo-full-windows-latest"
@@ -247,7 +269,6 @@ main() {
     verifyShell
 
     if [ "$currentOS" = "Linux" ] || [ "$currentOS" = "macOS" ]; then
-
         section "Checking prerequisites..."
         install_prerequisites
 
@@ -266,9 +287,9 @@ main() {
         eecho ""
         showFooter
 
-    else if [ "$currentOS" = "WindowsMsys2" ]; then
-
+    elif [[ "$currentOS" = "WindowsMsys2" ]]; then
         section "Creating environment..."
+        info "\nOS: $currentOS"
         msys_create_arturo_path
 
         section "Downloading..."
@@ -282,9 +303,8 @@ main() {
         section "Done!"
         eecho ""
         showFooter
-
     else
-        panic "Cannot continue. Unfortunately your OS is not supported by this auto-installer."
+        panic "Cannot continue. Unfortunately your OS is not supported by this auto-installer.";
     fi
 }
 

--- a/installer/stable.sh
+++ b/installer/stable.sh
@@ -206,8 +206,7 @@ install_arturo() {
 }
 
 msys_create_arturo_path() {
-    ARTURO_PATH="~/.arturo"
-    mkdir "$ARTURO_PATH/bin" "$ARTURO_PATH/lib"
+    ARTURO_DIR="$HOME/.arturo"
     info "~/.arturo/bin and ~/.arturo/lib created!"
 }
 

--- a/installer/stable.sh
+++ b/installer/stable.sh
@@ -208,19 +208,26 @@ install_arturo() {
 msys_create_arturo_path() {
     ARTURO_PATH="~/.arturo"
     mkdir "$ARTURO_PATH/bin" "$ARTURO_PATH/lib"
+    info "~/.arturo/bin and ~/.arturo/lib created!"
 }
 
 msys_download_arturo() {
 
     BIN_PATH="$ARTURO_PATH/bin"
-
     get_download_url $currentOS
+
+    info "Arturo downloaded into ~/.arturo/bin Folder!"
     curl -sSL $downloadUrl --output "$BIN_PATH/arturo.tar.gz"
+
+    info "Unpacking Arturo..."
     tar -zxf "$BIN_PATH/arturo.tar.gz" -C $BIN_PATH
+    info "Unpacked!"
+
 }
 
 msys_cleanup() {
     rm -f "$BIN_PATH/arturo.tar.gz"
+    info "~/.arturo/bin/arturo.tar.gz removed!"
 }
 
 ################################################
@@ -236,6 +243,7 @@ main() {
     verifyShell
 
     if [ "$currentOS" = "Linux" ] || [ "$currentOS" = "macOS" ]; then
+
         section "Checking prerequisites..."
         install_prerequisites
 
@@ -253,6 +261,24 @@ main() {
         section "Done!"
         eecho ""
         showFooter
+
+    else if [ "$currentOS" = "WindowsMsys2" ]; then
+
+        section "Creating environment..."
+        msys_create_arturo_path
+
+        section "Downloading..."
+        msys_download_arturo
+
+        section "Cleaning up..."
+        msys_cleanup
+
+        eecho ""
+
+        section "Done!"
+        eecho ""
+        showFooter
+
     else
         panic "Cannot continue. Unfortunately your OS is not supported by this auto-installer."
     fi

--- a/installer/stable.sh
+++ b/installer/stable.sh
@@ -211,7 +211,7 @@ msys_create_arturo_path() {
 
     create_directory "$ARTURO_DIR/bin"
     create_directory "$ARTURO_DIR/lib"
-    info "~/.arturo/bin and ~/.arturo/lib created!"
+    # info "~/.arturo/bin and ~/.arturo/lib created!"
 }
 
 msys_download_arturo() {
@@ -219,12 +219,12 @@ msys_download_arturo() {
     BIN_PATH="$ARTURO_DIR/bin"
     get_download_url $currentOS
 
-    info "Arturo downloaded into ~/.arturo/bin Folder!"
+    # info "Arturo downloaded into ~/.arturo/bin Folder!"
     curl -sSL $downloadUrl --output "$BIN_PATH/arturo.tar.gz"
 
-    info "Unpacking Arturo..."
+    # info "Unpacking Arturo..."
     tar -zxf "$BIN_PATH/arturo.tar.gz" -C $BIN_PATH
-    info "Unpacked!"
+    # info "Unpacked!"
 
 }
 
@@ -241,19 +241,19 @@ msys_fake_download_arturo() {
     # But the format is .tar.gz for unpack with tar command
     BIN_PATH="$ARTURO_DIR/bin"
     cp /home/development/arturo_setup/arturo.tar.gz $BIN_PATH
-    info "Arturo downloaded into ~/.arturo/bin Folder!"
+    # info "Arturo downloaded into ~/.arturo/bin Folder!"
 
-    info "Unpacking Arturo..."
+    # info "Unpacking Arturo..."
     tar -zxf "$BIN_PATH/arturo.tar.gz" -C $BIN_PATH
     mv $BIN_PATH/arturo-full-windows-latest/* $BIN_PATH/
-    info "Unpacked!"
+    # info "Unpacked!"
 
 }
 
 msys_cleanup() {
     rm -f "$BIN_PATH/arturo.tar.gz"
     rm --dir -f "$BIN_PATH/arturo-full-windows-latest"
-    info "~/.arturo/bin/arturo.tar.gz and ~/.arturo/bin/arturo-full-windows-latest/ removed!"
+    # info "~/.arturo/bin/arturo.tar.gz and ~/.arturo/bin/arturo-full-windows-latest/ removed!"
 }
 
 ################################################

--- a/installer/stable.sh
+++ b/installer/stable.sh
@@ -135,14 +135,14 @@ verifyOS(){
     case "$OSTYPE" in
         linux*)     currentOS="Linux" ;;
         linux-gnu*) currentOS="Linux" ;;
-        darwin*)    currentOS="macOS" ;; 
+        darwin*)    currentOS="macOS" ;;
         cygwin*)    currentOS="Windows" ;;
         msys*)      currentOS="Windows" ;;
         solaris*)   currentOS="Solaris" ;;
         freebsd*)   currentOS="FreeBSD" ;;
         bsd*)       currentOS="BSD" ;;
-        *)         
-            if [ `uname` = "Linux" ]; then 
+        *)
+            if [ `uname` = "Linux" ]; then
                 currentOS="Linux"
             elif [ `uname` = "FreeBSD" ]; then
                 currentOS="FreeBSD"
@@ -156,16 +156,16 @@ verifyOS(){
 
 verifyShell(){
     case "$SHELL" in
-        "/bin/zsh")     
+        "/bin/zsh")
             currentShell="zsh" ;
             shellRcFile="~/.zshrc" ;;
-        "/bin/bash")    
+        "/bin/bash")
             currentShell="bash" ;
             shellRcFile="~/.bashrc or ~/.profile" ;;
-        "/bin/sh")      
+        "/bin/sh")
             currentSheel="sh" ;
             shellRcFile="~/.profile" ;;
-        *)              
+        *)
             currentShell="unrecognized" ;
             shellRcFile="~/.profile" ;;
     esac
@@ -205,6 +205,24 @@ install_arturo() {
     cp $ARTURO_TMP_DIR/arturo ~/.arturo/bin
 }
 
+msys_create_arturo_path() {
+    ARTURO_PATH="~/.arturo"
+    mkdir "$ARTURO_PATH/bin" "$ARTURO_PATH/lib"
+}
+
+msys_download_arturo() {
+
+    BIN_PATH="$ARTURO_PATH/bin"
+
+    get_download_url $currentOS
+    curl -sSL $downloadUrl --output "$BIN_PATH/arturo.tar.gz"
+    tar -zxf "$BIN_PATH/arturo.tar.gz" -C $BIN_PATH
+}
+
+msys_cleanup() {
+    rm -f "$BIN_PATH/arturo.tar.gz"
+}
+
 ################################################
 # MAIN
 ################################################
@@ -220,7 +238,7 @@ main() {
     if [ "$currentOS" = "Linux" ] || [ "$currentOS" = "macOS" ]; then
         section "Checking prerequisites..."
         install_prerequisites
-        
+
         section "Downloading..."
         download_arturo
 

--- a/installer/stable.sh
+++ b/installer/stable.sh
@@ -216,7 +216,7 @@ msys_create_arturo_path() {
 
 msys_download_arturo() {
 
-    BIN_PATH="$ARTURO_PATH/bin"
+    BIN_PATH="$ARTURO_DIR/bin"
     get_download_url $currentOS
 
     info "Arturo downloaded into ~/.arturo/bin Folder!"

--- a/installer/stable.sh
+++ b/installer/stable.sh
@@ -206,7 +206,11 @@ install_arturo() {
 }
 
 msys_create_arturo_path() {
+
     ARTURO_DIR="$HOME/.arturo"
+
+    create_directory "$ARTURO_DIR/bin"
+    create_directory "$ARTURO_DIR/lib"
     info "~/.arturo/bin and ~/.arturo/lib created!"
 }
 

--- a/installer/stable.sh
+++ b/installer/stable.sh
@@ -137,7 +137,7 @@ verifyOS(){
         linux-gnu*) currentOS="Linux" ;;
         darwin*)    currentOS="macOS" ;;
         cygwin*)    currentOS="Windows" ;;
-        msys*)      currentOS="Windows" ;;
+        msys*)      currentOS="WindowsMsys2" ;;
         solaris*)   currentOS="Solaris" ;;
         freebsd*)   currentOS="FreeBSD" ;;
         bsd*)       currentOS="BSD" ;;


### PR DESCRIPTION
Read this issue: [Add Msys2 auto-install support #1](https://github.com/RickBarretto/arturo/issues/1#issue-1382319355)

## What I've done

1. Add create, download and cleanup functions 
   - Instead of create a temporary folder, my idea is download directly on `~/.arturo/bin`
   - Then Unpack the `arturo.tar.gz` and clean up...
2. Add `WindowsMsys2` as a `currentOS` variable instead just `Windows`
3. A test function was added, but must to be removed soon
  - This functions simulates a download with curl, while the `WindowsMsys2` file don't exists yet