### PR TITLE
fix: issue #1 @RickBarreto fork and #3

### DIFF
--- a/installer/nightly.sh
+++ b/installer/nightly.sh
@@ -156,13 +156,13 @@ verifyOS(){
 
 verifyShell(){
     case "$SHELL" in
-        "/bin/zsh")
+        */bin/zsh)
             currentShell="zsh" ;
             shellRcFile="~/.zshrc" ;;
-        "/bin/bash")
+        */bin/bash)
             currentShell="bash" ;
             shellRcFile="~/.bashrc or ~/.profile" ;;
-        "/bin/sh")
+        */bin/sh)
             currentSheel="sh" ;
             shellRcFile="~/.profile" ;;
         *)

--- a/installer/nightly.sh
+++ b/installer/nightly.sh
@@ -228,6 +228,15 @@ msys_download_arturo() {
 
 }
 
+msys_install_arturo() {
+    # info "Unpacking Arturo..."
+    tar -zxf "$BIN_PATH/arturo.tar.gz" -C $BIN_PATH
+    # info "Unpacked!"
+
+    mv $BIN_PATH/arturo-full-windows-latest/* $BIN_PATH/
+
+}
+
 # To generate this file on Msys2, use:
 # curl -sSL \
 #  https://github.com/arturo-lang/arturo/releases/download/v0.9.80/arturo-0.9.80-Windows-full.zip \
@@ -294,6 +303,9 @@ main() {
 
         section "Downloading..."
         msys_download_arturo
+
+        section "Installing..."
+        msys_install_arturo
 
         section "Cleaning up..."
         msys_cleanup

--- a/installer/stable.sh
+++ b/installer/stable.sh
@@ -156,13 +156,13 @@ verifyOS(){
 
 verifyShell(){
     case "$SHELL" in
-        "/bin/zsh")
+        */bin/zsh)
             currentShell="zsh" ;
             shellRcFile="~/.zshrc" ;;
-        "/bin/bash")
+        */bin/bash)
             currentShell="bash" ;
             shellRcFile="~/.bashrc or ~/.profile" ;;
-        "/bin/sh")
+        */bin/sh)
             currentSheel="sh" ;
             shellRcFile="~/.profile" ;;
         *)

--- a/installer/stable.sh
+++ b/installer/stable.sh
@@ -222,9 +222,14 @@ msys_download_arturo() {
     # info "Arturo downloaded into ~/.arturo/bin Folder!"
     curl -sSL $downloadUrl --output "$BIN_PATH/arturo.tar.gz"
 
+}
+
+msys_install_arturo() {
     # info "Unpacking Arturo..."
     tar -zxf "$BIN_PATH/arturo.tar.gz" -C $BIN_PATH
     # info "Unpacked!"
+
+    mv $BIN_PATH/arturo-full-windows-latest/* $BIN_PATH/
 
 }
 
@@ -294,6 +299,9 @@ main() {
 
         section "Downloading..."
         msys_download_arturo
+
+        section "Installing..."
+        msys_install_arturo
 
         section "Cleaning up..."
         msys_cleanup


### PR DESCRIPTION
## Explanation ([Fix #1 @RickBarretto](https://github.com/RickBarretto/arturo-lang.io/issues/1))
As finally a release for Msys2 [ocurred](https://github.com/arturo-lang/nightly/releases/tag/tag-2022-09-25), I decided to test it and see if all is alright.

1. I compared `Windows` and `WindowsMsys2` versions. 
    - They are the same, so it's right!
3. I uninstalled arturo from my machine
4. I runned `sh nightly.sh` to see if it's installing
    - But it was not installing
    - It was missing `mv` command, to move from unpacked folder to bin folder
    - This was working just with `msys_fake_download_arturo`, because this command was there

## What I've done
- created `msys_install_arturo`
- added `mv` command to `msys_install_arturo`
- added Install section

