### PR TITLE
Sanitize channel paths

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -155,7 +155,7 @@ jobs:
                 VERSION_TAG: ${{ steps.download.outputs.version_tag }}
                 CHANNEL: ${{ inputs.channel }}
               run: |
-                arturo tools/binarygen.art "$VERSION_TAG" "$CHANNEL"
+                arturo tools/binarygen.art "$VERSION_TAG" "$CHANNEL" "${{ inputs.test }}"
                 arturo tools/sitegen.art
                 arturo tools/indexgen.art
                 arturo tools/preprocessjs.art "$CHANNEL"

--- a/src/theme/components/head.html
+++ b/src/theme/components/head.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="has-navbar-fixed-top" lang="en">
     <head>
-        <base href="<||= getCanonical "/latest/" ||>">
+        <base href="<||= getCanonical getRootPath ||>">
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="robots" content="all">

--- a/tools/binarygen.art
+++ b/tools/binarygen.art
@@ -106,6 +106,7 @@ sortedBinaries: #.raw flatten arrange binaries [pfm,v][ index values platforms p
 ; Get version and build date from environment
 version: arg\0
 versionAlias: arg\1
+isTestBuild?: arg\2 = "true"
 buildDate: strip execute ~"date -u '+%Y-%m-%d %H:%M:%S UTC'"
 
 ; Generate the _index.art file
@@ -134,6 +135,7 @@ Details: #[
     build: 0
     arch: ~"|sys\cpu\arch|/|sys\os|"
     branch: versionAlias
+    test?: isTestBuild?
 ]
 
 if or? [contains? buildPart "."][3 < to :integer buildPart][

--- a/tools/miniwebize/webize.art
+++ b/tools/miniwebize/webize.art
@@ -38,7 +38,7 @@ Config: #[]
 Target: "build"
 Theme: "theme"
 ThemeSettings: # "theme/settings.art"
-WebsiteData: # "data/setup.art"
+WebsiteData: #[]
 InfoPadding: 13
 
 ;--------------------------
@@ -223,6 +223,9 @@ githubMarkdown: function [src][
 {_buildProject}: function [loc][
     switch exists? "config.art" [
         Config: #"config.art" 
+
+        inspect list "."
+        WebsiteData: #"data/setup.art"
 
         Data: #.data[]
         loop list "data" 'f [

--- a/tools/miniwebize/webize.art
+++ b/tools/miniwebize/webize.art
@@ -103,7 +103,6 @@ InfoPadding: 13
 ;--------------------------
 
 getWebsiteData: function [what][
-    inspect Data\setup
     return Data\setup\[what]
 ]
 
@@ -114,6 +113,8 @@ getRootPath: function [][
 
     if getWebsiteData 'test? ->
         rootPath: "/test/"
+
+    return rootPath
 ]
 
 linkTo: function [location][

--- a/tools/miniwebize/webize.art
+++ b/tools/miniwebize/webize.art
@@ -38,7 +38,6 @@ Config: #[]
 Target: "build"
 Theme: "theme"
 ThemeSettings: # "theme/settings.art"
-WebsiteData: #[]
 InfoPadding: 13
 
 ;--------------------------
@@ -104,7 +103,7 @@ InfoPadding: 13
 ;--------------------------
 
 getWebsiteData: function [what][
-    return WebsiteData\[what]
+    return Data\[what]
 ]
 
 getRootPath: function [][
@@ -224,15 +223,12 @@ githubMarkdown: function [src][
     switch exists? "config.art" [
         Config: #"config.art" 
 
-        inspect list "data"
-        WebsiteData: #"data/setup.art"
-
         Data: #[]
         loop list "data" 'f [
             if ".art" = extract.extension f ->
                 set Data (extract.basename f) -- extract.extension f do read f
         ]
-        inspect Data
+        ;inspect Data
 
         ;-------------------------
         ; Render pages

--- a/tools/miniwebize/webize.art
+++ b/tools/miniwebize/webize.art
@@ -103,7 +103,7 @@ InfoPadding: 13
 ;--------------------------
 
 getWebsiteData: function [what][
-    return Data\[what]
+    return Data\setup\[what]
 ]
 
 getRootPath: function [][

--- a/tools/miniwebize/webize.art
+++ b/tools/miniwebize/webize.art
@@ -224,15 +224,15 @@ githubMarkdown: function [src][
     switch exists? "config.art" [
         Config: #"config.art" 
 
-        inspect list "."
+        inspect list "data"
         WebsiteData: #"data/setup.art"
 
-        Data: #.data[]
+        Data: #[]
         loop list "data" 'f [
             if ".art" = extract.extension f ->
                 set Data (extract.basename f) -- extract.extension f do read f
         ]
-        ;inspect Data
+        inspect Data
 
         ;-------------------------
         ; Render pages

--- a/tools/miniwebize/webize.art
+++ b/tools/miniwebize/webize.art
@@ -103,6 +103,7 @@ InfoPadding: 13
 ;--------------------------
 
 getWebsiteData: function [what][
+    inspect Data\setup
     return Data\setup\[what]
 ]
 

--- a/tools/miniwebize/webize.art
+++ b/tools/miniwebize/webize.art
@@ -38,6 +38,7 @@ Config: #[]
 Target: "build"
 Theme: "theme"
 ThemeSettings: # "theme/settings.art"
+WebsiteData: # "data/setup.art"
 InfoPadding: 13
 
 ;--------------------------
@@ -101,6 +102,19 @@ InfoPadding: 13
 ;--------------------------
 ; Helpers
 ;--------------------------
+
+getWebsiteData: function [what][
+    return WebsiteData\[what]
+]
+
+getRootPath: function [][
+    rootPath: "/"
+    if "latest" = getWebsiteData 'branch ->
+        rootPath: "/latest/"
+
+    if getWebsiteData 'test? ->
+        rootPath: "/test/"
+]
 
 linkTo: function [location][
     i: 0 


### PR DESCRIPTION
Right now, there are quite a few hardcoded paths.

We must make sure that all paths (including resources, styles, scripts, internal links, etc) work fine, regardless of whether it's the `/latest` deployment, or a `/test` deployment, or a `/stable` (official) version.