### PR TITLE
Fix snippet share links

### DIFF
--- a/src/config/nginx.conf
+++ b/src/config/nginx.conf
@@ -189,7 +189,7 @@ server {
         root /usr/local/www/arturo/main/versions;
         try_files /$1/playground/index.html =404;
     }
-    
+     
     ######################################
     ## Version paths
     ######################################

--- a/src/config/nginx.conf
+++ b/src/config/nginx.conf
@@ -185,9 +185,16 @@ server {
         include fastcgi_params;
     }
 
-    location ~ ^/([^/]+)/playground/([a-zA-Z0-9]+)$ {
+    # Playground for versioned paths
+    location ~ ^/(latest|test|v[0-9.]+)/playground/([a-zA-Z0-9]+)$ {
         root /usr/local/www/arturo/main/versions;
         try_files /$1/playground/index.html =404;
+    }
+
+    # Playground for stable paths
+    location ~ ^/playground/([a-zA-Z0-9]+)$ {
+        root /usr/local/www/arturo/main/versions;
+        try_files /stable/playground/index.html =404;
     }
      
     ######################################

--- a/src/theme/resources/scripts/playground.js
+++ b/src/theme/resources/scripts/playground.js
@@ -390,7 +390,7 @@ function saveSnippet() {
                 
                 // Show modal after toast disappears
                 setTimeout(() => {
-                    const fullUrl = window.location.origin + window.location.pathname.split('/').slice(0, -1).join('/') + '/' + data.id;
+                    const fullUrl = "https://arturo-lang.io/%<[basePath]>%playground/" +data.id;
                     document.getElementById('snippet-link').value = fullUrl;
                     document.getElementById('save-modal').classList.add('is-active');
                 }, 3200);


### PR DESCRIPTION
Right now, playground links work fine from the /latest version, but not from the stable releases.

The issue seems to be two-fold:

- The Playground itself doesn't emit correct URLs
- The Nginx config properly recognizes only `/latest/` paths (when it comes to snippet links)