### PR TITLE
Fix installer script routes

### DIFF
--- a/src/config/nginx.conf
+++ b/src/config/nginx.conf
@@ -32,29 +32,33 @@ server {
     add_header Strict-Transport-Security "max-age=31536000" always;
     
     root /usr/local/www/arturo/main/versions;
-    
+        
     # Exact match for root - stable installer.sh
     location = / {
-        alias /usr/local/www/arturo/main/versions/stable/scripts/installer.sh;
+        default_type text/plain;
         add_header Content-Type text/plain;
+        try_files /stable/scripts/installer.sh =404;
     }
     
     # Exact match for /ps - stable installer.ps1
     location = /ps {
-        alias /usr/local/www/arturo/main/versions/stable/scripts/installer.ps1;
+        default_type text/plain;
         add_header Content-Type text/plain;
+        try_files /stable/scripts/installer.ps1 =404;
     }
     
     # Exact match for /latest - latest installer.sh
     location = /latest {
-        alias /usr/local/www/arturo/main/versions/latest/scripts/installer.sh;
+        default_type text/plain;
         add_header Content-Type text/plain;
+        try_files /latest/scripts/installer.sh =404;
     }
     
     # Exact match for /latest/ps - latest installer.ps1
     location = /latest/ps {
-        alias /usr/local/www/arturo/main/versions/latest/scripts/installer.ps1;
+        default_type text/plain;
         add_header Content-Type text/plain;
+        try_files /latest/scripts/installer.ps1 =404;
     }
 }
 


### PR DESCRIPTION
There was an issue when accessing `https://get.arturo-lang.io` which has already been fixed (@ the server).
Just updating the configuration here, mostly for reference.