### PR TITLE
Fix snippet links in browser urls

### DIFF
--- a/src/theme/resources/scripts/playground.js
+++ b/src/theme/resources/scripts/playground.js
@@ -375,7 +375,16 @@ function saveSnippet() {
                 updateButtonStates();
             }, 50);
             
-            window.history.pushState({}, '', window.location.pathname.split('/').slice(0, -1).join('/') + '/' + data.id);
+            var currentPath = window.location.pathname;
+            var newPath;
+            if (currentPath.endsWith('/playground') || currentPath.endsWith('/playground/')) {
+                // No snippet ID yet, just append
+                newPath = currentPath.replace(/\/$/, '') + '/' + data.id;
+            } else {
+                // Has a snippet ID already, replace it
+                newPath = currentPath.replace(/\/[^\/]+$/, '/' + data.id);
+            }
+            window.history.pushState({}, '', newPath);
             
             if (wasUpdate) {
                 // Just re-saved existing snippet - show toast only

--- a/src/theme/resources/scripts/playground.js
+++ b/src/theme/resources/scripts/playground.js
@@ -375,16 +375,7 @@ function saveSnippet() {
                 updateButtonStates();
             }, 50);
             
-            var currentPath = window.location.pathname;
-            var newPath;
-            if (currentPath.endsWith('/playground') || currentPath.endsWith('/playground/')) {
-                // No snippet ID yet, just append
-                newPath = currentPath.replace(/\/$/, '') + '/' + data.id;
-            } else {
-                // Has a snippet ID already, replace it
-                newPath = currentPath.replace(/\/[^\/]+$/, '/' + data.id);
-            }
-            window.history.pushState({}, '', newPath);
+            window.history.pushState({}, '', '%<[basePath]>%playground/' + data.id);
             
             if (wasUpdate) {
                 // Just re-saved existing snippet - show toast only
@@ -399,7 +390,7 @@ function saveSnippet() {
                 
                 // Show modal after toast disappears
                 setTimeout(() => {
-                    const fullUrl = "https://arturo-lang.io/%<[basePath]>%playground/" +data.id;
+                    const fullUrl = "https://arturo-lang.io/%<[basePath]>%playground/" + data.id;
                     document.getElementById('snippet-link').value = fullUrl;
                     document.getElementById('save-modal').classList.add('is-active');
                 }, 3200);

--- a/src/theme/resources/scripts/playground.js
+++ b/src/theme/resources/scripts/playground.js
@@ -375,7 +375,8 @@ function saveSnippet() {
                 updateButtonStates();
             }, 50);
             
-            window.history.pushState({}, '', '%<[basePath]>%playground/' + data.id);
+            const snippetPath = '%<[basePath]>%playground/' + data.id;
+            window.history.pushState({}, '', snippetPath);
             
             if (wasUpdate) {
                 // Just re-saved existing snippet - show toast only
@@ -390,7 +391,7 @@ function saveSnippet() {
                 
                 // Show modal after toast disappears
                 setTimeout(() => {
-                    const fullUrl = "https://arturo-lang.io/%<[basePath]>%playground/" + data.id;
+                    const fullUrl = "https://arturo-lang.io/" + snippetPath;
                     document.getElementById('snippet-link').value = fullUrl;
                     document.getElementById('save-modal').classList.add('is-active');
                 }, 3200);

--- a/src/theme/resources/scripts/playground.js
+++ b/src/theme/resources/scripts/playground.js
@@ -375,7 +375,7 @@ function saveSnippet() {
                 updateButtonStates();
             }, 50);
             
-            const snippetPath = '%<[basePath]>%playground/' + data.id;
+            const snippetPath = '/%<[basePath]>%playground/' + data.id;
             window.history.pushState({}, '', snippetPath);
             
             if (wasUpdate) {
@@ -391,7 +391,7 @@ function saveSnippet() {
                 
                 // Show modal after toast disappears
                 setTimeout(() => {
-                    const fullUrl = "https://arturo-lang.io/" + snippetPath;
+                    const fullUrl = "https://arturo-lang.io" + snippetPath;
                     document.getElementById('snippet-link').value = fullUrl;
                     document.getElementById('save-modal').classList.add('is-active');
                 }, 3200);


### PR DESCRIPTION
When a user "saves" a snippet, the server saves it etc and we show the snippet link in the popup dialog (which is sth like https://arturo-lang.io/test/playground/yoyuUY  or https://arturo-lang.io/playground/yoyuUY - if it's the main site) - we also "redirect" the browser url, so that it corresponds to the snippet in question. 

The problem is it's not redirected properly right now (= it goes to e.g. https://arturo-lang.io/test/yoyuUY, not where it should)